### PR TITLE
[RFC] Add support for non Float64 coefficient types

### DIFF
--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -1,5 +1,5 @@
-function createslack!(m::SOItoMOIBridge, cs, ::ZS)
-    m.slackmap[cs] = (0, 0, 0, 0.)
+function createslack!(m::SOItoMOIBridge{T}, cs, ::ZS) where T
+    m.slackmap[cs] = (0, 0, 0, zero(T))
 end
 function createslack!(m::SOItoMOIBridge, cs, ::S) where S <: Union{NS, PS}
     blk = newblock(m, -length(cs))
@@ -7,14 +7,14 @@ function createslack!(m::SOItoMOIBridge, cs, ::S) where S <: Union{NS, PS}
         m.slackmap[c] = (blk, i, i, vscaling(S))
     end
 end
-function createslack!(m::SOItoMOIBridge, cs, ::DS)
+function createslack!(m::SOItoMOIBridge{T}, cs, ::DS) where T
     d = getmatdim(length(cs))
     k = 0
     blk = newblock(m, d)
     for i in 1:d
         for j in i:d
             k += 1
-            m.slackmap[cs[k]] = (blk, i, j, i == j ? 1. : .5)
+            m.slackmap[cs[k]] = (blk, i, j, i == j ? one(T) : one(T)/2)
         end
     end
 end
@@ -43,7 +43,7 @@ _row(f::SAF, i) = 1
 _row(f::VAF, i) = f.outputindex[i]
 
 _getconstant(m::SOItoMOIBridge, s::MOI.AbstractScalarSet) = MOIU.getconstant(s)
-_getconstant(m::SOItoMOIBridge, s::MOI.AbstractSet) = 0.0
+_getconstant(m::SOItoMOIBridge{T}, s::MOI.AbstractSet) where T = zero(T)
 
 function loadcoefficients!(m::SOItoMOIBridge, cs::UnitRange, f::AF, s)
     f = MOIU.canonical(f) # sum terms with same variables and same outputindex
@@ -76,17 +76,17 @@ end
 
 _var(f::SVF, j) = f.variable
 _var(f::VVF, j) = f.variables[j]
-function loadconstraint!(m::SOItoMOIBridge, cr::CR, f::VF, s::ZS)
+function loadconstraint!(m::SOItoMOIBridge{T}, cr::CR, f::VF, s::ZS) where T
     cs = m.constrmap[cr.value]
     for j in length(cs)
         vm = m.varmap[_var(f, j).value]
         @assert length(vm) == 1
         (blk, i, j, coef, shift) = first(vm)
-        @assert coef == 1.0
+        @assert coef == one(T)
         @assert s isa MOI.Zeros || shift == s.value
         c = cs[j]
-        setconstraintcoefficient!(m.sdsolver, 1.0, c, blk, i, j)
-        setconstraintconstant!(m.sdsolver, 0.0, c)
+        setconstraintcoefficient!(m.sdsolver, one(T), c, blk, i, j)
+        setconstraintconstant!(m.sdsolver, zero(T), c)
     end
 end
 function loadconstraint!(m::SOItoMOIBridge, cr::CR, f::VF, s) end

--- a/src/load.jl
+++ b/src/load.jl
@@ -73,7 +73,7 @@ nconstraints{F<:SVF, S<:ZS}(cs::Vector{MOIU.C{F, S}}) = length(cs)
 nconstraints{F<:SVF, S<:SupportedSets}(cs::Vector{MOIU.C{F, S}}) = 0
 nconstraints{F, S<:BridgedSets}(cs::Vector{MOIU.C{F, S}}) = 0
 
-function resetbridges!(m)
+function resetbridges!(m::SOItoMOIBridge{T}) where T
     for s in m.int
         MOI.delete!(m, s)
     end
@@ -90,26 +90,26 @@ function resetbridges!(m)
         MOI.delete!(m, s)
     end
     m.bridgemap = Vector{Int}(m.sdinstance.nconstrs)
-    m.int = SplitIntervalBridge{Float64}[]
-    m.psdcs = PSDCScaledBridge{Float64}[]
-    m.soc = SOCtoPSDCBridge{Float64}[]
-    m.rsoc = RSOCtoPSDCBridge{Float64}[]
+    m.int = SplitIntervalBridge{T}[]
+    m.psdcs = PSDCScaledBridge{T}[]
+    m.soc = SOCtoPSDCBridge{T}[]
+    m.rsoc = RSOCtoPSDCBridge{T}[]
     m.double = CR[]
 end
 
-function initvariables!(m::SOItoMOIBridge)
-    m.objshift = 0.0
+function initvariables!(m::SOItoMOIBridge{T}) where T
+    m.objshift = zero(T)
     m.constr = 0
     m.nblocks = 0
     m.blockdims = Int[]
     m.free = IntSet(1:m.sdinstance.nvars)
-    m.varmap = Vector{Vector{Tuple{Int,Int,Int,Float64,Float64}}}(m.sdinstance.nvars)
+    m.varmap = Vector{Vector{Tuple{Int,Int,Int,T,T}}}(m.sdinstance.nvars)
 end
 
-function initconstraints!(m::SOItoMOIBridge)
+function initconstraints!(m::SOItoMOIBridge{T}) where T
     m.nconstrs = sum(MOIU.broadcastvcat(nconstraints, m.sdinstance))
     m.constrmap = Vector{UnitRange{Int}}(m.sdinstance.nconstrs)
-    m.slackmap = Vector{Tuple{Int, Int, Int, Float64}}(m.nconstrs)
+    m.slackmap = Vector{Tuple{Int, Int, Int, T}}(m.nconstrs)
 end
 
 _broadcastcall(f, m) = MOIU.broadcastcall(constrs -> f(m, constrs), m.sdinstance)

--- a/src/setbridges.jl
+++ b/src/setbridges.jl
@@ -47,12 +47,12 @@ struct PSDCScaledBridge{T}
     cr::CR{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}
 end
 unscalefunction(f::MOI.VectorOfVariables, diagidx) = unscalefunction(tofun(f), diagidx)
-function unscalefunction(f::MOI.VectorAffineFunction, diagidx)
+function unscalefunction(f::MOI.VectorAffineFunction{T}, diagidx) where T
     outputindex = f.outputindex
     variables = f.variables
     coefficients = copy(f.coefficients)
     constant = copy(f.constant)
-    s2 = sqrt(2)
+    s2 = sqrt(2*one(T))
     scalevec!(constant, 1/s2)
     for i in eachindex(outputindex)
         if !(outputindex[i] in diagidx)
@@ -86,11 +86,11 @@ function scalevec!(v, c)
     end
     v
 end
-function MOI.getattribute(m, a::MOI.ConstraintPrimal, c::PSDCScaledBridge)
-    scalevec!(MOI.getattribute(m, MOI.ConstraintPrimal(), c.cr), sqrt(2))
+function MOI.getattribute(m, a::MOI.ConstraintPrimal, c::PSDCScaledBridge{T}) where T
+    scalevec!(MOI.getattribute(m, MOI.ConstraintPrimal(), c.cr), sqrt(2one(T)))
 end
-function MOI.getattribute(m, a::MOI.ConstraintDual, c::PSDCScaledBridge)
-    scalevec!(MOI.getattribute(m, MOI.ConstraintDual(), c.cr), sqrt(2))
+function MOI.getattribute(m, a::MOI.ConstraintDual, c::PSDCScaledBridge{T}) where T
+    scalevec!(MOI.getattribute(m, MOI.ConstraintDual(), c.cr), sqrt(2one(T)))
 end
 
 """
@@ -156,9 +156,9 @@ _SOCtoPSDCaff(f::MOI.VectorAffineFunction) = _SOCtoPSDCaff(f, f[1])
 function MOI.getattribute(m, a::MOI.ConstraintPrimal, c::SOCtoPSDCBridge)
     MOI.getattribute(m, MOI.ConstraintPrimal(), c.cr)[1:c.dim]
 end
-function MOI.getattribute(m, a::MOI.ConstraintDual, c::SOCtoPSDCBridge)
+function MOI.getattribute(m, a::MOI.ConstraintDual, c::SOCtoPSDCBridge{T}) where T
     dual = MOI.getattribute(m, MOI.ConstraintDual(), c.cr)
-    tdual = 0.0
+    tdual = zero(T)
     j = c.dim
     i = 1
     n = div(c.dim * (c.dim+1), 2)
@@ -202,9 +202,9 @@ function MOI.getattribute(m, a::MOI.ConstraintPrimal, c::RSOCtoPSDCBridge)
     x[2] /= 2 # It is (2u*I)[1,1] so it needs to be divided by 2 to get u
     x
 end
-function MOI.getattribute(m, a::MOI.ConstraintDual, c::RSOCtoPSDCBridge)
+function MOI.getattribute(m, a::MOI.ConstraintDual, c::RSOCtoPSDCBridge{T}) where T
     dual = MOI.getattribute(m, MOI.ConstraintDual(), c.cr)
-    udual = 0.0
+    udual = zero(T)
     j = c.dim
     i = c.dim + 1
     n = div(c.dim * (c.dim+1), 2)

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -12,15 +12,15 @@ function unfree(m, v)
     delete!(m.free, v)
 end
 
-function loadvariable!(m::SOItoMOIBridge, vs::VIS, s::ZS)
+function loadvariable!(m::SOItoMOIBridge{T}, vs::VIS, s::ZS) where T
     blk = newblock(m, -length(vs))
     for (i, v) in enumerate(vs)
-        m.varmap[v] = [(blk, i, i, 1.0, _getconstant(m, s))]
+        m.varmap[v] = [(blk, i, i, one(T), _getconstant(m, s))]
         unfree(m, v)
     end
 end
-vscaling(::Type{<:NS}) = 1.
-vscaling(::Type{<:PS}) = -1.
+vscaling(::Type{<:NS}) = 1
+vscaling(::Type{<:PS}) = -1
 function loadvariable!{S<:Union{NS, PS}}(m::SOItoMOIBridge, vs::VIS, s::S)
     blk = newblock(m, -length(vs))
     for (i, v) in enumerate(vs)
@@ -38,24 +38,24 @@ function getmatdim(k::Integer)
     end
     n
 end
-function loadvariable!(m::SOItoMOIBridge, vs::VIS, ::DS)
+function loadvariable!(m::SOItoMOIBridge{T}, vs::VIS, ::DS) where T
     d = getmatdim(length(vs))
     k = 0
     blk = newblock(m, d)
     for i in 1:d
         for j in i:d
             k += 1
-            m.varmap[vs[k]] = [(blk, i, j, i == j ? 1.0 : 0.5, 0.0)]
+            m.varmap[vs[k]] = [(blk, i, j, i == j ? one(T) : one(T)/2, zero(T))]
             unfree(m, vs[k])
         end
     end
 end
-function loadvariable!(m::SOItoMOIBridge, cr, constr::SVF, s)
+function loadvariable!(m::SOItoMOIBridge{T}, cr, constr::SVF, s) where T
     vs = constr.variable.value
     if isfree(m, vs)
         loadvariable!(m, vs, s)
     else
-        push!(m.double, MOI.addconstraint!(m, MOI.ScalarAffineFunction([constr.variable], [1.], 0.), s))
+        push!(m.double, MOI.addconstraint!(m, MOI.ScalarAffineFunction([constr.variable], [one(T)], zero(T)), s))
     end
 end
 function loadvariable!(m::SOItoMOIBridge, cr, constr::VVF, s)
@@ -69,10 +69,10 @@ end
 
 function loadvariable!(m::SOItoMOIBridge, cr, constr::AF, s) end
 
-function loadfreevariables!(m::SOItoMOIBridge)
+function loadfreevariables!(m::SOItoMOIBridge{T}) where T
     for vi in m.free
         blk = newblock(m, -2)
         # x free transformed into x = y - z with y, z >= 0
-        m.varmap[vi] = [(blk, 1, 1, 1., 0.0), (blk, 2, 2, -1., 0.0)]
+        m.varmap[vi] = [(blk, 1, 1, one(T), zero(T)), (blk, 2, 2, -one(T), zero(T))]
     end
 end


### PR DESCRIPTION
This adds support for non Float64 types. This pull request depends on https://github.com/JuliaOpt/MathOptInterface.jl/pull/148.

I use it together with
```julia
module SDPAFile

using SemidefiniteOptInterface
SOI = SemidefiniteOptInterface

using MathOptInterface
MOI = MathOptInterface

import MathOptInterface.coefficienttype

export SDPAFileSolver

struct SDPAFileSolver{T} <: SOI.AbstractSDSolver
    filename
end

mutable struct SDPAFileInstance{T} <: SOI.AbstractSDSolverInstance
    filename
    mdims::Int
    blkdims::Vector{Int}
    rhs::Vector{T}
    list::Vector{Tuple{T, Int, Int, Int, Int}}
end

coefficienttype(::SDPAFileSolver{T}) where T = T

coefficienttype(::SDPAFileInstance{T}) where T = T

function SOI.SDSolverInstance(s::SDPAFileSolver{T}) where T
    SDPAFileInstance(s.filename, 0, Int[], T[], Tuple{T, Int, Int, Int, Int}[])
end

function SOI.initinstance!(s::SDPAFileInstance{T}, blkdims::Vector{Int}, nconstrs::Integer) where T<:Number
    s.mdims = nconstrs
    s.blkdims = blkdims
    s.rhs = Array{T,1}(nconstrs)
    s.list = Tuple{T, Int, Int, Int, Int}[]
end

function SOI.setconstraintconstant!(s::SDPAFileInstance{T}, val::T, constr::Integer) where T<:Number
   s.rhs[constr] = val 
end

function SOI.setconstraintcoefficient!(s::SDPAFileInstance{T}, val, constr::Integer, blk::Integer, i::Integer, j::Integer) where T<:Number
    push!(s.list, (val, constr, blk, i, j))        
end

function SOI.setobjectivecoefficient!(s::SDPAFileInstance{T}, val, blk::Integer, i::Integer, j::Integer) where T<:Number
    push!(s.list, (val, 0, blk, i, j))        
end

function MOI.optimize!(s::SDPAFileInstance{T}) where T<:Number
    open(s.filename, "w") do io
        println(io, s.mdims)
        println(io, length(s.blkdims))
        for i in s.blkdims
            print(io, "$i ")
        end
        println(io)
        for i in s.rhs
            print(io, "$i ")
        end
        println(io)
        for (val, constr, blk, i, j) in s.list
            println(io, "$constr $blk $i $j $val")    
        end
    end
end

end
```
to generate SDPA Sparse files with BigFloat precision.

Comments welcome!