### PR TITLE
Add support for general coefficient types

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -52,13 +52,13 @@ nconstraints{F<:SAF, S<:SupportedSets}(cs::Vector{MOIU.C{F, S}}) = length(cs)
 nconstraints{F<:SVF, S<:ZS}(cs::Vector{MOIU.C{F, S}}) = length(cs)
 nconstraints{F<:SVF, S<:SupportedSets}(cs::Vector{MOIU.C{F, S}}) = 0
 
-function initvariables!(m::SOItoMOIBridge)
-    m.objshift = 0.0
+function initvariables!(m::SOItoMOIBridge{T}) where T
+    m.objshift = zero(T)
     m.constr = 0
     m.nblocks = 0
     m.blockdims = Int[]
     m.free = IntSet(1:m.sdinstance.nextvariableid)
-    m.varmap = Vector{Vector{Tuple{Int,Int,Int,Float64,Float64}}}(m.sdinstance.nextvariableid)
+    m.varmap = Vector{Vector{Tuple{Int,Int,Int,T,T}}}(m.sdinstance.nextvariableid)
 end
 
 function initconstraints!(m::SOItoMOIBridge)

--- a/src/setbridges.jl
+++ b/src/setbridges.jl
@@ -16,13 +16,13 @@ struct PSDCScaledBridge{T}
     cr::CR{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}
 end
 unscalefunction(f::MOI.VectorOfVariables, diagidx) = unscalefunction(tofun(f), diagidx)
-function unscalefunction(f::MOI.VectorAffineFunction, diagidx)
+function unscalefunction(f::MOI.VectorAffineFunction{T}, diagidx) where T
     outputindex = f.outputindex
     variables = f.variables
     coefficients = copy(f.coefficients)
     constant = copy(f.constant)
-    s2 = sqrt(2)
-    scalevec!(constant, 1/s2)
+    s2 = sqrt(T(2))
+    scalevec!(constant, one(T)/s2)
     for i in eachindex(outputindex)
         if !(outputindex[i] in diagidx)
             coefficients[i] /= s2
@@ -56,12 +56,12 @@ function scalevec!(v, c)
     v
 end
 MOI.canget(instance::MOI.AbstractInstance, a::MOI.ConstraintPrimal, c::PSDCScaledBridge) = true
-function MOI.get(instance::MOI.AbstractInstance, a::MOI.ConstraintPrimal, c::PSDCScaledBridge)
-    scalevec!(MOI.get(instance, MOI.ConstraintPrimal(), c.cr), sqrt(2))
+function MOI.get(instance::MOI.AbstractInstance, a::MOI.ConstraintPrimal, c::PSDCScaledBridge{T}) where T
+    scalevec!(MOI.get(instance, MOI.ConstraintPrimal(), c.cr), sqrt(T(2)))
 end
 MOI.canget(instance::MOI.AbstractInstance, a::MOI.ConstraintDual, c::PSDCScaledBridge) = true
-function MOI.get(instance::MOI.AbstractInstance, a::MOI.ConstraintDual, c::PSDCScaledBridge)
-    scalevec!(MOI.get(instance, MOI.ConstraintDual(), c.cr), sqrt(2))
+function MOI.get(instance::MOI.AbstractInstance, a::MOI.ConstraintDual, c::PSDCScaledBridge{T}) where T
+    scalevec!(MOI.get(instance, MOI.ConstraintDual(), c.cr), sqrt(T(2)))
 end
 
 function trimap(i, j)


### PR DESCRIPTION
This adds support for general coefficient types. (I will close the other pull request). 

I didn't add a function or attribute to query the coefficient type since there didn't seem to be consensus on the best approach for this. (Instead, I parameterize the methods in my own code by PSDCScaled{T} instead of AbstractSolver for now.)